### PR TITLE
Add support for optional return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ language, it will be generated as `??? [key] ???`.
       
 In oder to break generation on missing key set `i18nBreakOnMissingKeys := true` in `build.sbt`. 
 
+Alternatively, you can set `i18nOptionalReturnValues` to `true` in `build.sbt` to generate `Option` return types 
+for the key values.
+
+Above options are mutually exclusive.
+
 ## Contribution policy ##
 
 Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.


### PR DESCRIPTION
Hi,

Previously, we had the option to return "??? {key} ???" in generated code if the string can not be found by the locale.

This change introduce a second option to allow generation Option[String] return types.