### PR TITLE
Generate a Boolean param for an ICU select on true/false

### DIFF
--- a/src/main/scala/tech/ant8e/sbt/i18n/BundleEmitter.scala
+++ b/src/main/scala/tech/ant8e/sbt/i18n/BundleEmitter.scala
@@ -87,6 +87,7 @@ case class BundleEmitter(
   private def toScalaType(paramType: ParamType) =
     paramType match {
       case AnyParam     => "Any"
+      case BooleanParam => "Boolean"
       case DateParam    => "ZonedDateTime"
       case DoubleParam  => "Double"
       case LongParam    => "Long"
@@ -348,6 +349,7 @@ private[i18n] object BundleEmitter {
 
     sealed trait ParamType
     case object AnyParam                                       extends ParamType
+    case object BooleanParam                                   extends ParamType
     case object DateParam                                      extends ParamType
     case object DoubleParam                                    extends ParamType
     case object LongParam                                      extends ParamType
@@ -437,9 +439,10 @@ private[i18n] object BundleEmitter {
           val format = mf.getFormats.head
           javaTextFormatToParamType(format)
         case MessagePattern.ArgType.SELECT                               =>
-          // Build enum with all values
           val variants = node.getComplexStyle.getVariants.asScala.toList.map(_.getSelector)
-          EnumParam(node.getName, variants)
+          // A select on true/false is a Boolean, not an enum ('true' is not a valid Scala identifier anyway)
+          if (isBooleanSelect(variants)) BooleanParam
+          else EnumParam(node.getName, variants) // Build enum with all values
         case _                                                           =>
           // For plural, selectordinal and choice check variant selectors and select between long and double
           val allVariantsInteger =
@@ -449,6 +452,13 @@ private[i18n] object BundleEmitter {
           if (allVariantsInteger) LongParam else DoubleParam
 
       }
+
+    private val booleanSelectors = Set("true", "false")
+
+    private def isBooleanSelect(variants: List[String]): Boolean = {
+      val selectors = variants.toSet - "other"
+      selectors.nonEmpty && selectors.subsetOf(booleanSelectors)
+    }
 
     // extract child messages to put to the loop queue
     private def getNext(node: ArgNode): List[PatternNode] =

--- a/src/sbt-test/sbt-i18n/simple/src/main/i18n/i18n.conf
+++ b/src/sbt-test/sbt-i18n/simple/src/main/i18n/i18n.conf
@@ -2,6 +2,7 @@ fr = {
   test = 1
   test2 ="param {0}"
   test3 ="param {0,date}"
+  test5 ="{isToday, select, true {Today} other {{date, date, ::MMM d}}}"
   sub {
     test4= 2
   }

--- a/src/sbt-test/sbt-i18n/simple/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-i18n/simple/src/main/scala/Main.scala
@@ -7,6 +7,7 @@ class Main {
   val text2 = tech.ant8e.i18n.Bundle.fr.test2("hi")
   val text3 = tech.ant8e.i18n.Bundle.fr.test3(java.time.ZonedDateTime.now())
   val text4 = tech.ant8e.i18n.Bundle.fr.sub.test4
+  val text5 = tech.ant8e.i18n.Bundle.fr.test5(true, java.time.ZonedDateTime.now())
 }
 
 object Main {

--- a/src/test/scala/tech/ant8e/sbt/i18n/BundleEmitterSpec.scala
+++ b/src/test/scala/tech/ant8e/sbt/i18n/BundleEmitterSpec.scala
@@ -514,4 +514,35 @@ class BundleEmitterSpec extends AnyFlatSpec with Matchers {
     BundleEmitter(config, packageName).emitValues("en") should be(expected)
 
   }
+
+  it must "emit a Boolean for a select on true/false" in {
+    import BundleEmitter.quote
+    val message      =
+      "{isToday, select, true {Today} other {{date, date, ::MMM d}}}"
+    val configString =
+      s"""
+        |en {
+        |    day = "$message"
+        |}
+        |""".stripMargin
+
+    val config   = ConfigFactory.parseString(configString.stripMargin)
+    val emitter  = BundleEmitter(config, packageName)
+    val expected =
+      """abstract class I18N {
+        |protected val locale: Locale
+        |def day(isToday: Boolean, date: ZonedDateTime): String
+        |}""".stripMargin
+
+    emitter.emitStructure() should be(expected)
+    emitter.emitValues("en") should be(
+      s"""object en extends I18N {
+        |override protected val locale: Locale = Locale.forLanguageTag("en")
+        |
+        |def day(isToday: Boolean, date: ZonedDateTime): String = new MessageFormat(${quote(
+          message
+        )}, locale).format(java.util.Map.of("isToday", isToday, "date", toCalendar(date)))
+        |}""".stripMargin
+    )
+  }
 }

--- a/src/test/scala/tech/ant8e/sbt/i18n/ParamsExtractorSpec.scala
+++ b/src/test/scala/tech/ant8e/sbt/i18n/ParamsExtractorSpec.scala
@@ -87,6 +87,21 @@ class ParamsExtractorSpec
       (
         "{gender, select, male {He uses} female {She uses} other {They use}}",
         List(Param("gender", EnumParam("gender", List("male", "female", "other"))))
+      ),
+      (
+        "{isToday, select, true {Today} other {{date, date, ::MMM d}}}",
+        List(
+          Param("isToday", BooleanParam),
+          Param("date", DateParam)
+        )
+      ),
+      (
+        "{enabled, select, true {on} false {off} other {unknown}}",
+        List(Param("enabled", BooleanParam))
+      ),
+      (
+        "{hidden, select, false {shown} other {hidden}}",
+        List(Param("hidden", BooleanParam))
       )
     )
 


### PR DESCRIPTION
## Problem

An ICU `select` argument is always turned into an enum, with one `case object` per selector. When the selectors are `true`/`false` — a common way to express a boolean condition in a message — the generated code does not compile, because `true` and `false` are Scala keywords:

```hocon
en = {
  day = "{isToday, select, true {Today} other {{date, date, ::MMM d}}}"
}
```

```scala
sealed trait IsToday

object IsToday {
  case object true extends IsToday   // error: `identifier` expected but `true` found
  case object other extends IsToday
}

def day(isToday: IsToday, date: ZonedDateTime): String
```

## Change

A `select` whose selectors (ignoring `other`) are a subset of `{true, false}` now produces a `Boolean` parameter instead of an enum:

```scala
def day(isToday: Boolean, date: ZonedDateTime): String
```

This covers `true`/`other`, `false`/`other` and `true`/`false`/`other`. Any other set of selectors keeps the existing enum behaviour.

No change is needed on the formatting side: ICU resolves a `select` sub-message from the argument's `toString`, so the boxed `java.lang.Boolean` matches the `true` and `false` branches and falls back to `other` as expected.

## Tests

- `ParamsExtractorSpec`: three new table entries — `true`/`other`, `true`/`false`/`other`, `false`/`other`.
- `BundleEmitterSpec`: a new case asserting the emitted structure and values for a boolean select.
- `sbt-test/sbt-i18n/simple`: a message with a boolean select plus a call site in `Main.scala`, so the scripted test verifies the generated code actually compiles and runs.

`sbt test` and `sbt scripted` both pass.
